### PR TITLE
adds dokka support to generate javadocs for the kotlin only projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 out
 node_modules
-target
+target/
 
 dependency-reduced-pom.xml
 classpath.txt

--- a/debug/service/pom.xml
+++ b/debug/service/pom.xml
@@ -31,6 +31,36 @@
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals><goal>javadocJar</goal></goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/ls/service/pom.xml
+++ b/ls/service/pom.xml
@@ -31,6 +31,36 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals><goal>javadocJar</goal></goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,11 @@
                     <version>3.2.4</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <version>1.9.20</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.1.0</version>


### PR DESCRIPTION
Maven Central requires javadoc files for every project, even if the javadoc file is empty there still has to be one pro-project.

The build process for some of the cql-language-server projects still generated javadoc files.

Unforunately, the cql-ls-service and cql-ls-debug-service do not. Those projects use main.kt as entry points and teh shading plugin interferes with the javadoc plugin. This doesn't affect the jar executable, just doesn't create the needed javadoc files. This cauased maven central to reject those projects because of the missing javadoc files.

The PR adds the dokka plugin which generates javadocs for kotlin only projects.
