### PR TITLE
fixes threading issue with context loading

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debug/server/pom.xml
+++ b/debug/server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/debug/service/pom.xml
+++ b/debug/service/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ls/server/pom.xml
+++ b/ls/server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ls/server/src/main/java/org/opencds/cqf/cql/ls/server/manager/IgContextManager.kt
+++ b/ls/server/src/main/java/org/opencds/cqf/cql/ls/server/manager/IgContextManager.kt
@@ -28,7 +28,7 @@ class IgContextManager(private val contentService: ContentService) {
 
     fun getContext(uri: URI): NpmProcessor? {
         val root = Uris.getHead(uri)
-        return cachedContext.getOrPut(root) { readContext(root) }.orElse(null)
+        return cachedContext.computeIfAbsent(root) { readContext(it) }.orElse(null)
     }
 
     protected fun clearContext(uri: URI) {

--- a/ls/server/src/test/kotlin/org/opencds/cqf/cql/ls/server/manager/IgContextManagerTest.kt
+++ b/ls/server/src/test/kotlin/org/opencds/cqf/cql/ls/server/manager/IgContextManagerTest.kt
@@ -24,6 +24,8 @@ import java.io.InputStream
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 
 class IgContextManagerTest {
     private lateinit var manager: IgContextManager
@@ -141,6 +143,55 @@ class IgContextManagerTest {
 
         localManager.getContext(TEST_URI) // should still be cached
         assertEquals(countAfterFirst, readCount, "Unrelated file change should not clear cache")
+    }
+
+    // -----------------------------------------------------------------------
+    // getContext — concurrent callers trigger readContext() exactly once
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun getContext_concurrentCalls_onlyReadsContextOnce() {
+        val readCount = AtomicInteger(0)
+        val cs =
+            object : ContentService {
+                override fun locate(
+                    root: URI,
+                    identifier: VersionedIdentifier,
+                ) = emptySet<URI>()
+
+                override fun read(uri: URI): InputStream? {
+                    readCount.incrementAndGet()
+                    return null
+                }
+            }
+
+        // Establish baseline: how many content-service reads does one getContext() trigger?
+        val baselineManager = IgContextManager(cs)
+        baselineManager.getContext(TEST_URI)
+        val readsPerContext = readCount.get()
+
+        // Reset and run N threads simultaneously against a cold cache.
+        readCount.set(0)
+        val localManager = IgContextManager(cs)
+        val threadCount = 10
+        val startGate = CountDownLatch(1)
+        val threads =
+            (1..threadCount).map {
+                Thread {
+                    startGate.await()
+                    localManager.getContext(TEST_URI)
+                }
+            }
+        threads.forEach { it.start() }
+        startGate.countDown()
+        threads.forEach { it.join() }
+
+        assertEquals(
+            readsPerContext,
+            readCount.get(),
+            "Concurrent getContext() calls should invoke readContext() exactly once " +
+                "(expected $readsPerContext reads, got ${readCount.get()})",
+        )
     }
 
     // -----------------------------------------------------------------------

--- a/ls/service/pom.xml
+++ b/ls/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/debug/pom.xml
+++ b/plugin/debug/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.4.1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.opencds.cqf.cql.ls</groupId>
     <artifactId>cql-ls</artifactId>
     <packaging>pom</packaging>
-    <version>4.4.1</version>
+    <version>4.5.0-SNAPSHOT</version>
 
     <name>CQL Language Server</name>
     <description>A Language Server for CQL implementing the LSP</description>


### PR DESCRIPTION
fixes #130 

When calling getContext, from the vscode extension, the LSP4J creates multiple threads that call `getContext()`. If the resource isn't in the cache the `IgContext` goes searching. This is a big issue with the hover provider, it can causes multiple threads to go out and search for the same files, when the cache is cold. If `IgContext` can't find the file locally, or in `.fhir/packages` then it attempts to download from the `npm registry`.  Once the cache is loaded, not an issue but when starting up it is a problem.