### PR TITLE
Release/4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 
 
+
+## v4.9.0
+
+Date: 2026-06-25
+
+* bump version to cql-language-server to 4.9.0 
+* change clinical-reasoning to version 4.9.0
+* fix issue with library names with hyphens
+
+
 ## v4.8.0
 
 Date: 2026-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 Date: 2026-06-25
 
 * bump version to cql-language-server to 4.9.0 
-* change clinical-reasoning to version 4.9.0
+* change clinical-reasoning to version 4.8.0
 * fix issue with library names with hyphens
 
 

--- a/ls/server/pom.xml
+++ b/ls/server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.opencds.cqf.cql.ls</groupId>
         <artifactId>cql-ls</artifactId>
-        <version>4.9.0-SNAPSHOT</version>
+        <version>4.9.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ls/server/src/main/kotlin/org/opencds/cqf/cql/ls/server/service/FileContentService.kt
+++ b/ls/server/src/main/kotlin/org/opencds/cqf/cql/ls/server/service/FileContentService.kt
@@ -122,13 +122,22 @@ class FileContentService(
             val indexOfExtension = name.lastIndexOf(".")
             if (indexOfExtension >= 0) name = name.substring(0, indexOfExtension)
 
-            val indexOfVersionSeparator = name.lastIndexOf("-")
-            var version: Version? = null
-            if (indexOfVersionSeparator >= 0) {
-                version = tryParseVersion(name.substring(indexOfVersionSeparator + 1))
-                if (version != null) name = name.substring(0, indexOfVersionSeparator)
+            // Walk backward through hyphen-separated segments, accepting only a
+            // suffix that parses as a valid version (majorVersion != null). This
+            // handles hyphenated library names (e.g. SUR716-011Assertion.cql)
+            // alongside multi-segment MAT-style versions (e.g. "-0.1.000-cibuild").
+            var searchFrom = name.length
+            while (true) {
+                val indexOfVersionSeparator = name.lastIndexOf("-", searchFrom - 1)
+                if (indexOfVersionSeparator < 0) break
+                val candidateVersion = name.substring(indexOfVersionSeparator + 1)
+                val version = tryParseVersion(candidateVersion)
+                if (version?.majorVersion != null) {
+                    return Pair(name.substring(0, indexOfVersionSeparator), version)
+                }
+                searchFrom = indexOfVersionSeparator
             }
-            return Pair(name, version)
+            return Pair(name, null)
         }
     }
 

--- a/ls/server/src/test/kotlin/org/opencds/cqf/cql/ls/server/service/FileContentServiceTest.kt
+++ b/ls/server/src/test/kotlin/org/opencds/cqf/cql/ls/server/service/FileContentServiceTest.kt
@@ -296,6 +296,58 @@ class FileContentServiceTest {
         assertEquals(setOf(file.toURI()), result)
     }
 
+    // ── Hyphenated library names ─────────────────────────────────────────────
+    // Library identifiers may contain hyphens when declared with a delimited
+    // identifier (e.g. `library `SUR716-011Assertion``). The filename-to-name
+    // parser must not split on a hyphen unless the trailing segment is a valid
+    // semantic version (majorVersion != null).
+
+    @Test
+    fun searchFolder_hyphenatedLibraryName_unversionedFile_returnsFile() {
+        // Exercises getNameAndVersion through the companion searchFolder API.
+        // Without the fix, "011Assertion" is silently accepted as a version
+        // and the name is truncated to "SUR716", causing a mismatch.
+        val cqlFile = File(tempDir, "SUR716-011Assertion.cql").also { it.createNewFile() }
+
+        val result = FileContentService.searchFolder(tempDir.toURI(), id("SUR716-011Assertion"))
+
+        assertNotNull(result)
+        assertEquals(cqlFile.canonicalPath, result!!.canonicalPath)
+    }
+
+    @Test
+    fun locate_hyphenatedLibraryName_unversionedFile_returnsFile() {
+        // Primary regression test for the "Could not load source for library
+        // SUR716-011Assertion" error. getNameAndVersion must return the full
+        // name when no valid version suffix is present.
+        val cqlFile = File(tempDir, "SUR716-011Assertion.cql").also { it.createNewFile() }
+
+        val result = svc(tempDir).locate(tempDir.toURI(), id("SUR716-011Assertion"))
+
+        assertEquals(setOf(cqlFile.toURI()), result)
+    }
+
+    @Test
+    fun locate_hyphenatedLibraryName_versionedFile_exactVersionRequested_returnsFile() {
+        val cqlFile = File(tempDir, "SUR716-011Assertion-1.0.0.cql").also { it.createNewFile() }
+
+        val result = svc(tempDir).locate(tempDir.toURI(), id("SUR716-011Assertion", "1.0.0"))
+
+        assertEquals(setOf(cqlFile.toURI()), result)
+    }
+
+    @Test
+    fun locate_hyphenatedLibraryName_versionedFile_noVersionRequested_returnsFile() {
+        // Exercises the bfsCompatible path: getNameAndVersion must correctly
+        // separate the version suffix from the hyphenated library name so the
+        // name comparison succeeds.
+        val cqlFile = File(tempDir, "SUR716-011Assertion-1.0.0.cql").also { it.createNewFile() }
+
+        val result = svc(tempDir).locate(tempDir.toURI(), id("SUR716-011Assertion"))
+
+        assertEquals(setOf(cqlFile.toURI()), result)
+    }
+
     // ── Namespace-qualified resolution ────────────────────────────────────────
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.opencds.cqf.cql.ls</groupId>
     <artifactId>cql-ls</artifactId>
     <packaging>pom</packaging>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>4.9.0</version>
 
     <name>CQL Language Server</name>
     <description>A Language Server for CQL implementing the LSP</description>
@@ -20,7 +20,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <cqf-fhir-cr.version>4.7.0</cqf-fhir-cr.version>
+        <cqf-fhir-cr.version>4.8.0</cqf-fhir-cr.version>
         <cql.version>4.9.0</cql.version>
         <logback.version>1.2.13</logback.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
- bump verison to 4.9.0
- update Clinical Reasoning package to v4.8.0
- fix issue with library name handling

closes #144 
